### PR TITLE
Missing if-statement end brace

### DIFF
--- a/texitrender.php
+++ b/texitrender.php
@@ -368,6 +368,7 @@ class texitrender_plugin_texit {
 	$info .= '\\dokubackground{';
 	$info .= $latex->_latexEntities($hash['backgroundtext']) . "}\n";
       }
+    }
     foreach ( array_keys($this->_texit_conf) as $val ) {
       if (isset($hash[$val])) {
 	$this->_texit_conf[$val] = $hash[$val];


### PR DESCRIPTION
Fix typo introduced in a860bda: missing if-statement end brace.
