### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -32,7 +32,7 @@ class action_plugin_texit extends DokuWiki_Action_Plugin {
    * @param Doku_Event_Handler $controller DokuWiki's event controller object
    * @return void
    */
-  public function register(Doku_Event_Handler &$controller) {
+  public function register(Doku_Event_Handler $controller) {
      $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this,
                                 'handle_action_act_preprocess');
   }

--- a/syntax.php
+++ b/syntax.php
@@ -70,7 +70,7 @@ class syntax_plugin_texit extends DokuWiki_Syntax_Plugin {
   /**
    * Handle the match
    */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     //print_r(array('match' => $match, 'state' => $state, "pos" => $pos, "handler" => $handler));
     //print "<br>";
     if ($state == DOKU_LEXER_UNMATCHED) {
@@ -89,7 +89,7 @@ class syntax_plugin_texit extends DokuWiki_Syntax_Plugin {
   /**
    * Create output
    */
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
     global $ID;
     list($state, $substate, $match, $pos) = $data;
     if (!isset($this->_texit)) {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
